### PR TITLE
Added proper error handling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,23 @@ var gulp        = require('gulp'),
   jshintStyle   = require('jshint-stylish'),
   replace       = require('gulp-replace'),
   notify        = require('gulp-notify'),
+  beep          = require('beepbeep'),
+  colors        = require('colors'),
+  plumber       = require('gulp-plumber'),
   path          = require('path');
+
+// error handling convenience wrapper
+gulp.plumbedSrc = function(){
+  return gulp.src.apply(gulp, arguments)
+    .pipe(plumber({
+      errorHandler: function(err) {
+        beep();
+        console.log('[ERROR:]'.bold.red);
+        console.log(err.messageFormatted);
+        this.emit('end');
+      }
+    }));
+};
 
 gulp.task('browser-sync', function() {
   browserSync({
@@ -23,7 +39,7 @@ gulp.task('browser-sync', function() {
 });
 
 gulp.task('html', function(){
-  gulp.src(path.join(__dirname, 'views/**/*.html'))
+  gulp.plumbedSrc(path.join(__dirname, 'views/**/*.html'))
     .pipe(gulp.dest(path.join(__dirname, 'build')))
     .pipe(browserSync.reload({
       stream: true
@@ -31,7 +47,7 @@ gulp.task('html', function(){
 });
 
 gulp.task('sass', function () {
-  return gulp.src('sass/**/*.scss')
+  return gulp.plumbedSrc('sass/**/*.scss')
     .pipe(sass())
     .pipe(minifyCSS())
     .pipe(gulp.dest('./build/css/'))
@@ -39,7 +55,7 @@ gulp.task('sass', function () {
 });
 
 gulp.task('jshint', function() {
-  return gulp.src('./js/**/*.js')
+  return gulp.plumbedSrc('./js/**/*.js')
     .pipe(jshint())
     .pipe(jshint.reporter(jshintStyle))
     .pipe(jshint.reporter('fail'))
@@ -47,7 +63,7 @@ gulp.task('jshint', function() {
 });
 
 gulp.task('scripts', function() {
-  gulp.src('js/project.js')
+  gulp.plumbedSrc('js/project.js')
     .pipe(browserify({
       insertGlobals : true,
       debug : !gulp.env.production

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "gulp-sass": "^2.0.1",
     "gulp-uglify": "^1.2.0",
     "jshint-stylish": "^1.0.2",
-    "path": "^0.11.14"
+    "path": "^0.11.14",
+    "gulp-plumber": "~1.0.1",
+    "beepbeep": "~1.2.0",
+    "colors": "~1.1.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Put in a fix to address Issue #4 which is apparently a known issue for Gulp. FYI, this may change when Gulp 4 comes out see [here](https://github.com/gulpjs/gulp/issues/71)

I opted for using `gulp-plumber` because it [was recommended](https://gist.github.com/floatdrop/8269868) and following the comments I added a convenience wrapper so now instead of calling `gulp.src` you can do `gulp.plumbedSrc` and it will automatically include the custom error handler.

The new error handling comes out below and will not crash the watch task. I also made it so that it will do a little beep sound. Let me know if there are issues!

![image](https://cloud.githubusercontent.com/assets/2054339/8274531/718ce016-1848-11e5-8154-1ecfa1870dc5.png)

Related Reading: http://stackoverflow.com/questions/23971388/prevent-errors-from-breaking-crashing-gulp-watch
